### PR TITLE
added Canada.ca typography

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,5 +1,6 @@
 import "../icomoon/style.css";
 import "../styles/globals.css";
+import "../styles/fonts.css";
 import LanguageProvider from "../context/languageProvider";
 
 function MyApp({ Component, pageProps }) {

--- a/styles/fonts.css
+++ b/styles/fonts.css
@@ -1,0 +1,1 @@
+@import url("https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,100;0,300;0,400;0,700;0,900;1,100;1,300;1,400;1,700;1,900&family=Noto+Sans:wght@400;700&display=swap")


### PR DESCRIPTION
# Description

[Canada.ca Typography](https://lj-decd.atlassian.net/browse/LJ-33?atlOrigin=eyJpIjoiZDA0YjNkMGVhYWZhNGEwNTk0MDEzYzlhZTNmNTFjYWUiLCJwIjoiaiJ9)

Most of the functionality was added in the search bar PR (global CSS and tailwind config) so all that was left was to import the fonts and add them as an import in our _app.js

## Test Instructions

1. Pull branch and copy paste the below code into index.js

```html   
<h1>test 1</h1>
<h2>test 2</h2>
<h3>test 3</h3>
<h4>test 4</h4>
<h5>test 5</h5>
<h6>test 6</h6>
<p>test paragraph</p>
```
2. Pull branch and type `npm run dev` to see that the proper fonts are being used

## Meets Definition of Done

- [x] Fonts for headers use Lato and body fonts use Noto Sans.
