### PR TITLE
LJ-98 Fix Header Fonts

### DIFF
--- a/components/molecules/TitleSection.js
+++ b/components/molecules/TitleSection.js
@@ -6,7 +6,7 @@ import { HorizontalRule } from "../atoms/HorizontalRule";
 export default function TitleSection(props) {
   return (
     <div>
-      <h2 className="pb-2 font-bold">{props.title}</h2>
+      <h2 className="pb-2 pt-6">{props.title}</h2>
       <HorizontalRule />
       <p className="pt-4 pb-6">{props.description}</p>
     </div>

--- a/components/molecules/TitleSection.js
+++ b/components/molecules/TitleSection.js
@@ -6,7 +6,7 @@ import { HorizontalRule } from "../atoms/HorizontalRule";
 export default function TitleSection(props) {
   return (
     <div>
-      <h2 className="pb-2 pt-6">{props.title}</h2>
+      <h1 className="pb-2 pt-6">{props.title}</h1>
       <HorizontalRule />
       <p className="pt-4 pb-6">{props.description}</p>
     </div>

--- a/components/organisms/TopicBox.js
+++ b/components/organisms/TopicBox.js
@@ -11,7 +11,7 @@ export default function TopicBox(props) {
     <div className="md:shadow-lg h-auto min-h-96 w-full rounded-md border-2 pl-3 pr-3">
       <div className="grid grid-cols-3 grid-flow-row">
         <div className="col-span-2 mt-8">
-          <h2>{props.title}</h2>
+          <h2 className="text-h3">{props.title}</h2>
         </div>
         <div className="pt-1 col-span-1 xxl:ml-8">
           <Image
@@ -24,7 +24,7 @@ export default function TopicBox(props) {
         </div>
       </div>
       <p className="pb-4">{props.body}</p>
-      <h3 className="font-bold pb-4 pt-2">Find information about</h3>{" "}
+      <h3 className="text-h5 pb-4">Find information about</h3>{" "}
       <ul className="flex flex-wrap gap-2 pb-2">
         {props.subtopics.map((d, idx) => (
           <li key="idx" className="h-auto w-auto rounded-md border-2 pl-2 pr-2">

--- a/components/organisms/TopicBox.js
+++ b/components/organisms/TopicBox.js
@@ -8,12 +8,12 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
  */
 export default function TopicBox(props) {
   return (
-    <div className="md:shadow-lg h-auto min-h-96 w-full rounded-md border-2 pl-2">
+    <div className="md:shadow-lg h-auto min-h-96 w-full rounded-md border-2 pl-3 pr-3">
       <div className="grid grid-cols-3 grid-flow-row">
-        <div className="col-span-2">
-          <h3 className="font-extrabold">{props.title}</h3>
+        <div className="col-span-2 mt-8">
+          <h3>{props.title}</h3>
         </div>
-        <div className="col-span-1">
+        <div className="col-span-1 xxl:ml-8">
           <Image
             src={props.image}
             alt={props.imgalt}
@@ -23,7 +23,7 @@ export default function TopicBox(props) {
           ></Image>
         </div>
       </div>
-      <p>{props.body}</p>
+      <p className="pb-4">{props.body}</p>
       <h4 className="font-bold pb-4 pt-2">Find information about</h4>{" "}
       <ul className="flex flex-wrap gap-2 pb-2">
         {props.subtopics.map((d, idx) => (
@@ -32,7 +32,7 @@ export default function TopicBox(props) {
           </li>
         ))}
       </ul>
-      <div className="pb-2">
+      <div className="pb-5 pt-1">
         <Link href={props.url}>
           <a className="font-bold">
             {" "}

--- a/components/organisms/TopicBox.js
+++ b/components/organisms/TopicBox.js
@@ -11,9 +11,9 @@ export default function TopicBox(props) {
     <div className="md:shadow-lg h-auto min-h-96 w-full rounded-md border-2 pl-3 pr-3">
       <div className="grid grid-cols-3 grid-flow-row">
         <div className="col-span-2 mt-8">
-          <h3>{props.title}</h3>
+          <h2>{props.title}</h2>
         </div>
-        <div className="col-span-1 xxl:ml-8">
+        <div className="pt-1 col-span-1 xxl:ml-8">
           <Image
             src={props.image}
             alt={props.imgalt}
@@ -24,7 +24,7 @@ export default function TopicBox(props) {
         </div>
       </div>
       <p className="pb-4">{props.body}</p>
-      <h4 className="font-bold pb-4 pt-2">Find information about</h4>{" "}
+      <h3 className="font-bold pb-4 pt-2">Find information about</h3>{" "}
       <ul className="flex flex-wrap gap-2 pb-2">
         {props.subtopics.map((d, idx) => (
           <li key="idx" className="h-auto w-auto rounded-md border-2 pl-2 pr-2">

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -280,31 +280,31 @@ header {
 #wb-srch, .srchbox {
   padding-top: 1em;
 }
-h2, .h2 {
+.h2 {
   font-size: 1.8em;
 }
-h1, .h1, h2, .h2, h3, .h3, h4, .h4, h5, .h5, h6, .h6 {
+.h1, .h2, .h3, .h4, .h5, .h6 {
   -webkit-font-variant-ligatures: no-common-ligatures;
   font-variant-ligatures: no-common-ligatures;
   font-weight: 600;
 }
-h1, .h1, h2, .h2, h3, .h3, h4, .h4, h5, .h5, h6, .h6, .home .home-most-requested li {
+.home .home-most-requested li {
   font-family: Lato,sans-serif;
 }
-h1, .h1, h2, .h2 {
+.h1, .h2 {
   margin-top: 38px;
 }
-h1, .h1, h2, .h2, h3, .h3, h4, .h4, h5, .h5, h6, .h6 {
+.h1, .h2, .h3, .h4, .h5, .h6 {
   font-weight: 700;
 }
-h2, .h2 {
+.h2 {
   font-size: 26px;
 }
-h1, .h1, h2, .h2, h3, .h3 {
+.h1, .h2, .h3 {
   margin-top: 23px;
   margin-bottom: 11.5px;
 }
-h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6 {
+.h1, .h2, .h3, .h4, .h5, .h6 {
   font-family: inherit;
   font-weight: 500;
   line-height: 1.1;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -11,6 +11,7 @@ module.exports = {
       sm: ["16px", "22px"],
       base: ["18px", "28px"],
       p: ["20px", "30px"],
+      h5: ["20px", "30px"],
       h4: ["22px", "20px"],
       h3: ["24px", "24.3px"],
       h2: ["30px", "33.5px"],


### PR DESCRIPTION
# Description

[LJ-98 Headers are all wrong font](https://lj-decd.atlassian.net/browse/LJ-98?atlOrigin=eyJpIjoiZGE5NmY1MmVkYTQ2NGMzMjllZGYyNGYwNjZlMDVmYTQiLCJwIjoiaiJ9 )

Got rid of conflicting styles from global css so headers now default to proper styling. Fixed up the TopicBox component and TitleSection component so they don't have hard coded font weight anymore. Also slightly adjusted some padding on the topic boxes and added margins on the icon so it's a reasonable size on large screens. Responsive design needs work in the future to address other screen sizes. 

## Test Instructions

1. Pull in branch
2. Type ```npm run dev```

## Meets Definition of Done

- [x] All headers should be “Lato” with a font weight of 600.
