### PR TITLE
Added space between links, underlined links, space above and below

### DIFF
--- a/components/atoms/BreadLink.js
+++ b/components/atoms/BreadLink.js
@@ -6,12 +6,12 @@ import Link from "next/link";
 export function BreadLink({ url, text, arrow }) {
   return (
     <Link href={url}>
-      <a className="underline">
+      <a className="underline text-visited-link">
         {arrow && (
           <FontAwesomeIcon
             icon={faAngleRight}
             size="sm"
-            color="#2B4380"
+            color="#333"
             className="mx-4"
           />
         )}

--- a/components/atoms/BreadLink.js
+++ b/components/atoms/BreadLink.js
@@ -6,12 +6,16 @@ import Link from "next/link";
 export function BreadLink({ url, text, arrow }) {
   return (
     <Link href={url}>
-      <a>
-        {"  "}
+      <a className="underline">
         {arrow && (
-          <FontAwesomeIcon icon={faAngleRight} size="sm" color="#2B4380" />
+          <FontAwesomeIcon
+            icon={faAngleRight}
+            size="sm"
+            color="#2B4380"
+            className="mx-4"
+          />
         )}
-        {"  "}
+
         {text}
       </a>
     </Link>

--- a/components/atoms/SideMenu.js
+++ b/components/atoms/SideMenu.js
@@ -5,7 +5,7 @@ export function SideMenu({ title, links }) {
   return (
     <div
       id="Sidemenu"
-      className="mt-2 p-4 sticky w-full top-0 block lg:max-w-sm float-left text-white"
+      className="p-4 sticky w-full top-0 block lg:max-w-sm float-left text-white"
     >
       <h2 className="font-bold text-p mb-2">{title}</h2>
 

--- a/pages/having-a-baby.js
+++ b/pages/having-a-baby.js
@@ -23,7 +23,7 @@ export default function lifejourney() {
         siteTitle={t.havingAChildBannerTitle}
         headline={t.havingAChildBannerText}
       />
-      <div id="wb-bc" className="container pt-4">
+      <div id="wb-bc" className="container my-6">
         <Breadcrumb />
       </div>
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -63,6 +63,7 @@ module.exports = {
         "form-input-gray": "#555",
         "form-input-border-gray": "#ccc",
         "canada-footer-font": "#284162",
+        "visited-link": "#7834bc",
       },
       width: {
         "40px": "40px",


### PR DESCRIPTION
# Description

[LJ-133 Fix the breadcrumbs on the "having a child" page](https://lj-decd.atlassian.net/browse/LJ-133?atlOrigin=eyJpIjoiYmNmYjIwMDA1OGM2NDFhZGI0Y2ZjNTYwNzhmM2M1NDciLCJwIjoiaiJ9)

Added vertical margin to the breadcrumbs on the having a baby page and space between the links and the arrow. Also made it so the links were underlined. 

## Suggestion

Canada.ca breadcrumbs have the links in the purple "visited" color, do we want to imitate that?

## Test Instructions

1. Pull in branch
2. Type `npm run dev`
3. Click on Having a Baby topic box to view breadcrumbs

## Meets Definition of Done

- [x] The breadcrumbs have more space between them, around them
