### PR TITLE
added form label, changed p tag to h2

### DIFF
--- a/components/atoms/DropDown.js
+++ b/components/atoms/DropDown.js
@@ -7,7 +7,7 @@ import PropTypes from "prop-types";
 export default function DropDown(props) {
   return (
     <details>
-      <summary className="h-46px max-w-350px w-full bg-details-button-gray focus:ring-black focus:ring-inset-1 focus:ring-2 active:bg-details-button-active-gray hover:bg-details-button-hover-gray rounded py-12px px-5px font-body text-sm text-center text-custom-blue-reportButton list-item cursor-pointer border border-outset border-details-button-gray xxs:text-xs">
+      <summary className="h-46px max-w-350px w-full bg-details-button-gray focus:ring-black focus:ring-inset-1 focus:ring-2 active:bg-details-button-active-gray hover:bg-details-button-hover-gray rounded py-12px px-5px font-body text-sm text-center text-custom-blue-reportButton list-item cursor-pointer border border-outset border-details-button-gray">
         {props.text}
       </summary>
       <div className="max-w-350px w-full min-h-200px bg-gray-light-200 mt-1 p-15px border border-details-border-gray rounded ring-inset ring-1 ring-gray-light-200">

--- a/components/atoms/SearchBar.js
+++ b/components/atoms/SearchBar.js
@@ -13,11 +13,13 @@ export function SearchBar(props) {
         onSubmit={props.onSubmit}
       >
         <div className="searchBox">
+          <label htmlFor="searchBar">Search</label>
           <input
             type="text"
             placeholder={props.placeholder}
             className="placeholder-text-gray text-text-gray searchInput font-body py-1 px-2 focus:outline-none"
             onChange={props.onChange}
+            id="searchBar"
           />
         </div>
         <div>

--- a/pages/index.js
+++ b/pages/index.js
@@ -33,9 +33,9 @@ export default function Home({ topicsData, errorCode }) {
           <h1 className="pb-2 pt-6">{t.landingPageTitle}</h1>
           <hr className="h-1 bg-hr-red-bar"></hr>
           <p className="pt-10 pb-10">{t.landingPageContent}</p>
-          <p className="text-h3 font-display font-bold pb-10">
+          <h2 className="text-h3 font-display font-bold pb-10">
             {t.landingPageSubtitle}
-          </p>
+          </h2>
         </div>
       </div>
       <div className="container flex flex-wrap">


### PR DESCRIPTION
# Description
This PR encompasses the 2 below tasks as they were both very small accessibility fixes and made more sense to be in one PR.
[LJ-228 Accessibility for H3 header issue](https://lj-decd.atlassian.net/browse/LJ-228?atlOrigin=eyJpIjoiMzc2Y2VmMDIzMjgwNDRmMDg3YWMyNjVhOGI0M2VhNTIiLCJwIjoiaiJ9)
[LJ-113 Add label to search bar](https://lj-decd.atlassian.net/browse/LJ-113?atlOrigin=eyJpIjoiY2ZmYTZmMjNlOTA2NGQwNzhiODAxZGMyZDliYzYwY2EiLCJwIjoiaiJ9)

Added a label to the search bar form and changed the landing page subtitle to be an `h2` (with h3 styling as per designs) rather than a `p` tag so the page hierarchy is correct. Also noticed at large screen sizes that the summary text for the report a problem component was super small and not really centered, so went ahead and fixed that as well.

## Test Instructions

1. Pull in branch
2. Type `npm run dev`
3. Use WAVE tool to confirm that the above accessibility issues are no longer present

## Meets Definition of Done

- [x] There is no warning saying the search form is missing a label
- [x] There is no warning that the subtitle text appears to be a heading but is not a heading element 
