### PR TITLE
Added phase banner and tests

### DIFF
--- a/components/atoms/PhaseBanner.js
+++ b/components/atoms/PhaseBanner.js
@@ -1,0 +1,34 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+/**
+ * Displays the PhaseBanner on the page
+ */
+
+export const PhaseBanner = ({ phase, children }) => {
+  return (
+    <div className="bg-gray-100 sm:max-h-14">
+      <div className="flex items-start py-4 layout-container">
+        <span className="font-body text-xs leading-5 sm:text-sm sm:leading-5 uppercase tracking-normal border-2 border-black px-2">
+          {phase}
+        </span>
+        <p className="font-body text-xxs sm:text-xs break-words ml-4 pt-1">
+          {children}
+        </p>
+      </div>
+    </div>
+  );
+};
+
+PhaseBanner.propTypes = {
+  /**
+   * Phase stage in the PhaseBanner
+   */
+  phase: PropTypes.string.isRequired,
+  /**
+   * Phase stage in the PhaseBanner
+   */
+  children: PropTypes.string.isRequired,
+};
+
+export default PhaseBanner;

--- a/components/atoms/PhaseBanner.test.js
+++ b/components/atoms/PhaseBanner.test.js
@@ -1,0 +1,27 @@
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/extend-expect";
+import { axe, toHaveNoViolations } from "jest-axe";
+import { PhaseBanner } from "./PhaseBanner";
+
+expect.extend(toHaveNoViolations);
+
+const phase = "Omega";
+
+describe("PhaseBanner tests", () => {
+  it("renders PhaseBanner in its primary state", () => {
+    render(<PhaseBanner phase={phase}>PhaseBanner Text</PhaseBanner>);
+    const phaseElement = screen.getByText("Omega");
+    const textElement = screen.getByText("PhaseBanner Text");
+    expect(phaseElement).toBeTruthy();
+    expect(textElement).toBeTruthy();
+  });
+
+  it("has no a11y violations", async () => {
+    const { container } = render(
+      <PhaseBanner phase={phase}>PhaseBanner Text</PhaseBanner>
+    );
+    const results = await axe(container);
+
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/components/organisms/Header.js
+++ b/components/organisms/Header.js
@@ -1,5 +1,6 @@
 import { HeaderLang } from "../atoms/HeaderLang";
 import { HeaderLogo } from "../atoms/HeaderLogo";
+import { PhaseBanner } from "../atoms/PhaseBanner";
 import { useContext } from "react";
 import { LanguageContext } from "../../context/languageProvider";
 import en from "../../locales/en";
@@ -14,6 +15,7 @@ export function Header() {
     <div className="par iparys_inherited">
       <div className="global-header">
         <header>
+          <PhaseBanner phase={t.Alpha}>{t.alphaText}</PhaseBanner>
           <div id="wb-bnr" className="container">
             <div className="row">
               <HeaderLang />

--- a/locales/en.js
+++ b/locales/en.js
@@ -162,4 +162,8 @@ export default {
   landingPageContent:
     "The Life Journey Information Service helps make your journey through life easier by showing you the step-by-step process of a life event in your journey and show you the support that might be available to help you.",
   landingPageSubtitle: "Select a journey to get started",
+
+  //Phase Banner
+  Alpha: "Alpha",
+  alphaText: "This site will change as we test ideas.",
 };

--- a/locales/fr.js
+++ b/locales/fr.js
@@ -163,4 +163,8 @@ export default {
   landingPageContent:
     "Le service d'information sur le parcours de vie contribue à faciliter votre cheminement dans la vie en vous montrant le processus étape par étape d'un événement de votre parcours et en vous indiquant le soutien qui pourrait être disponible pour vous aider.",
   landingPageSubtitle: "Sélectionnez un voyage pour commencer",
+
+  //Phase Banner
+  Alpha: "Alpha",
+  alphaText: "Ce site changera au fur et à mesure que nous testons des idées.",
 };


### PR DESCRIPTION
# Description

[LJ-230 Implement Alpha Phase Banner in header](https://lj-decd.atlassian.net/browse/LJ-230?atlOrigin=eyJpIjoiYTY4MTRjMzIyNjJiNDA3NDgxOGU0MTBhZjAxYzRlOTkiLCJwIjoiaiJ9)

Added the Phase Banner from Alpha Site. Currently it sits inside the `Header` component but outside of the container so the gray background stretches the entire screen width. This means it doesn't always align with the other header contents when changing the size of the window, but if the idea for the immediate future is to change our layout to be closer to Alpha's, then this won't be an issue.

## Test Instructions

1. Pull in branch
2. Type `npm run dev`

## Meets Definition of Done

- [x] Meets design spec
- [x] unit tests are included
