### PR TITLE
Lj 195 language content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ yarn-error.log*
 
 # local env files
 .env
+.env.local
 
 # vercel
 .vercel

--- a/components/atoms/DateModified.js
+++ b/components/atoms/DateModified.js
@@ -1,6 +1,25 @@
+import propTypes from "prop-types";
+
 /**
  * Contains build time stamp
  */
 export default function DateModified(props) {
-  return <div>Date modified: {process.env.NEXT_PUBLIC_BUILD_DATE}</div>;
+  return (
+    <div id={props.id}>
+      {props.text} {process.env.NEXT_PUBLIC_BUILD_DATE}
+    </div>
+  );
 }
+
+DateModified.defaultProps = {
+  id: "date-modified",
+  text: "Date Modified:",
+};
+
+DateModified.propTypes = {
+  // text to be displayed
+  text: propTypes.string,
+
+  // id of the element for testing if needed
+  id: propTypes.string.isRequired,
+};

--- a/components/organisms/PageDetails.js
+++ b/components/organisms/PageDetails.js
@@ -1,15 +1,26 @@
 import DateModified from "../atoms/DateModified";
 import ReportProblem from "../atoms/ReportProblem";
+
+import { useContext } from "react";
+import { LanguageContext } from "../../context/languageProvider";
+
+import en from "../../locales/en";
+import fr from "../../locales/fr";
+
 /**
  * contains the timestamp and other page details just above the footer
  */
 export function PageDetails(props) {
+  const { items } = useContext(LanguageContext);
+  const language = items.language;
+  const t = language === "en" ? en : fr;
+
   return (
     <div className="container pb-8 pt-8">
       <div className="pb-8">
         <ReportProblem />
       </div>
-      <DateModified />
+      <DateModified text={t.dateModified} />
     </div>
   );
 }

--- a/locales/en.js
+++ b/locales/en.js
@@ -29,6 +29,7 @@ export default {
   // Footer
   //
 
+  dateModified: "Date Modified:",
   // Landscape Links
 
   contactLink: "https://www.canada.ca/en/contact.html",

--- a/locales/fr.js
+++ b/locales/fr.js
@@ -29,6 +29,7 @@ export default {
   // Footer
   //
 
+  dateModified: "Date de modification :",
   // Landscape Links
 
   contactLink: "https://www.canada.ca/fr/contact.html",

--- a/pages/api/topics.js
+++ b/pages/api/topics.js
@@ -18,7 +18,9 @@ export function getLocalData() {
 //
 
 export async function getTopics(language) {
-  const res = await fetch(`${process.env.NEXT_CONTENT_API}`);
+  const res = await fetch(
+    `${process.env.NEXT_CONTENT_API}?date=${process.env.NEXT_PUBLIC_BUILD_DATE}`
+  );
   const error = res.ok ? false : res.statusCode;
   const apiData = await res.json();
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -76,16 +76,18 @@ export async function getStaticProps(language) {
 
     apiData.entities.map((entity) => {
       if (entity.properties.contentFragment) {
-        topics.push({
-          title: entity.properties.elements.title.value,
-          body: entity.properties.elements.description.value,
-          image: "/images/family.png",
-          imgalt: "Alt text TBD",
-          url: entity.properties.elements.link.value,
-          subtopics: entity.properties.elements.tags.value
-            .toString()
-            .split(","),
-        });
+        if (entity.properties.elements.lang.value === language.locale) {
+          topics.push({
+            title: entity.properties.elements.title.value,
+            body: entity.properties.elements.description.value,
+            image: "/images/family.png",
+            imgalt: "Alt text TBD",
+            url: entity.properties.elements.link.value,
+            subtopics: entity.properties.elements.tags.value
+              .toString()
+              .split(","),
+          });
+        }
       }
     });
 


### PR DESCRIPTION
# Description

[LJ-195] Display Topic boxes based on the Language 

The model for the Topic-Boxes contain a Languge key that can be used to select the content base on the page current language
this code cannot be be general as applies only to an specific property of the Topic-Model 

## Test Instructions

1. Get the branch then run

## Meets Definition of Done

- [ ] Meets design spec
- [ ] unit tests are included


[LJ-195]: https://lj-decd.atlassian.net/browse/LJ-195