### PR TITLE
Modified phase banner into SCLabs banner, modified province selector …

### DIFF
--- a/components/atoms/PhaseBanner.js
+++ b/components/atoms/PhaseBanner.js
@@ -5,14 +5,19 @@ import PropTypes from "prop-types";
  * Displays the PhaseBanner on the page
  */
 
-export const PhaseBanner = ({ phase, children }) => {
+export const PhaseBanner = ({ phase, children, link, linkText }) => {
   return (
-    <div className="bg-gray-100 sm:max-h-14">
-      <div className="flex items-start py-4 layout-container">
-        <span className="font-body text-xs leading-5 sm:text-sm sm:leading-5 uppercase tracking-normal border-2 border-black px-2">
-          {phase}
-        </span>
-        <p className="font-body text-xxs sm:text-xs break-words ml-4 pt-1">
+    <div className="bg-circle-color">
+      <div className="flex py-4 layout-container">
+        <div className="flex-container">
+          <div className="mb-3 py-1 font-body text-xs leading-5 h-full sm:text-sm sm:leading-5 font-black tracking-normal border-2 border-black px-2 bg-white text-circle-color w-max">
+            {phase}
+          </div>
+          <div className="mb-3 underline text-white">
+            <a href={link}>{linkText}</a>
+          </div>
+        </div>
+        <p className="font-body text-white block text-xs break-words pt-1">
           {children}
         </p>
       </div>
@@ -25,6 +30,14 @@ PhaseBanner.propTypes = {
    * Phase stage in the PhaseBanner
    */
   phase: PropTypes.string.isRequired,
+  /**
+   * Link back to projects
+   */
+  link: PropTypes.string.isRequired,
+  /**
+   * Text for link
+   */
+  linkText: PropTypes.string.isRequired,
   /**
    * Phase stage in the PhaseBanner
    */

--- a/components/atoms/PhaseBanner.test.js
+++ b/components/atoms/PhaseBanner.test.js
@@ -6,10 +6,15 @@ import { PhaseBanner } from "./PhaseBanner";
 expect.extend(toHaveNoViolations);
 
 const phase = "Omega";
+const linkText = "Back to something";
 
 describe("PhaseBanner tests", () => {
   it("renders PhaseBanner in its primary state", () => {
-    render(<PhaseBanner phase={phase}>PhaseBanner Text</PhaseBanner>);
+    render(
+      <PhaseBanner phase={phase} linkText={linkText} link="">
+        PhaseBanner Text
+      </PhaseBanner>
+    );
     const phaseElement = screen.getByText("Omega");
     const textElement = screen.getByText("PhaseBanner Text");
     expect(phaseElement).toBeTruthy();
@@ -18,7 +23,9 @@ describe("PhaseBanner tests", () => {
 
   it("has no a11y violations", async () => {
     const { container } = render(
-      <PhaseBanner phase={phase}>PhaseBanner Text</PhaseBanner>
+      <PhaseBanner phase={phase} linkText={linkText} link="">
+        PhaseBanner Text
+      </PhaseBanner>
     );
     const results = await axe(container);
 

--- a/components/atoms/Select.js
+++ b/components/atoms/Select.js
@@ -6,7 +6,7 @@ export default function Select(props) {
       {props.label}
       <select
         defaultValue={props.defaultValue}
-        className="ml-2 mb-2 py-1 px-2 shadow-inner w-36 overflow-ellipsis border border-black rounded-xl focus-visible:outline-none focus:ring-black focus:ring-1 transition-shadow duration-300 focus:w-auto"
+        className="ml-2 mb-2 py-1 px-2 shadow-inner w-36 overflow-ellipsis border-2 border-gray-300 focus-visible:outline-none focus:ring-black focus:ring-1 transition-shadow duration-300 focus:w-auto bg-white"
         name={props.name}
         onChange={(e) => props.onChange(e.currentTarget.value)}
       >

--- a/components/organisms/Header.js
+++ b/components/organisms/Header.js
@@ -57,7 +57,9 @@ export function Header({ bannerTitle, bannerText, breadcrumbItems }) {
       </nav>
 
       <header>
-        <PhaseBanner phase={t.Alpha}>{t.alphaText}</PhaseBanner>
+        <PhaseBanner phase={t.Alpha} link="#" linkText={t.backToProject}>
+          {t.testSiteText}
+        </PhaseBanner>
 
         <div className="layout-container flex-col flex lg:flex lg:flex-row justify-between mt-2">
           <div className="flex flex-row justify-between items-center lg:mt-7 mt-1.5">

--- a/locales/en.js
+++ b/locales/en.js
@@ -168,6 +168,8 @@ export default {
   landingPageSubtitle: "Select a journey to get started",
 
   //Phase Banner
-  Alpha: "Alpha",
-  alphaText: "This site will change as we test ideas.",
+  Alpha: "Test site",
+  testSiteText:
+    "You cannot apply for services or benefits through this test site. Parts of this site may not work and will change.",
+  backToProject: "Back to projects",
 };

--- a/locales/fr.js
+++ b/locales/fr.js
@@ -169,6 +169,8 @@ export default {
   landingPageSubtitle: "Sélectionnez un voyage pour commencer",
 
   //Phase Banner
-  Alpha: "Alpha",
-  alphaText: "Ce site changera au fur et à mesure que nous testons des idées.",
+  Alpha: "Test site (fr)",
+  testSiteText:
+    "You cannot apply for services or benefits through this test site. Parts of this site may not work and will change. (fr)",
+  backToProject: "Back to projects (fr)",
 };

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -10,14 +10,19 @@ html {
 
 @layer base {
   /* Font families */
-  h1, h2, h3, h4, h5 {
+  h1,
+  h2,
+  h3,
+  h4,
+  h5 {
     @apply font-display font-semibold;
   }
-  h6, summary {
+  h6,
+  summary {
     @apply font-display;
   }
   p {
-    @apply font-body
+    @apply font-body;
   }
   /* Font sizes */
   h1 {
@@ -32,7 +37,8 @@ html {
   h4 {
     @apply text-h4;
   }
-  h5, p {
+  h5,
+  p {
     @apply text-p;
   }
   h6 {
@@ -46,7 +52,7 @@ html {
     border-style: outset;
   }
 
-/* 
+  /* 
   below is the CSS from Canada theme
 */
 
@@ -62,12 +68,12 @@ html {
     -moz-osx-font-smoothing: grayscale;
   }
   .glyphicon-chevron-up:before {
-    content: "^"; 
+    content: "^";
   }
 
   .visible-xs {
     display: none !important;
-  } 
+  }
 
   /* Accordion CSS rules*/
   details.accordion {
@@ -79,14 +85,14 @@ html {
     cursor: pointer;
   }
   details.accordion > summary:hover {
-    background-color: #CFCFCF;
+    background-color: #cfcfcf;
   }
   details.accordion > summary:focus {
     border: 1px solid black;
-    background-color: #CFCFCF;
+    background-color: #cfcfcf;
   }
   details.accordion > summary:active {
-    background-color: #BBBFC5;
+    background-color: #bbbfc5;
   }
   details.accordion > summary::-webkit-details-marker {
     display: none;
@@ -99,14 +105,14 @@ html {
   .menuLink {
     display: inline-flex;
     flex-direction: column;
-    justify-content: space-between; 
+    justify-content: space-between;
     padding: 2px 12px 2px 0px;
     color: black;
     text-decoration: none;
   }
   .menuLink::after {
     content: attr(data-text);
-    content: attr(data-text)/" ";
+    content: attr(data-text) / " ";
     height: 0;
     visibility: hidden;
     overflow: hidden;
@@ -119,21 +125,20 @@ html {
     }
   }
 
-  .menuLink:active, .menuLink:focus, .menuLink:hover {
+  .menuLink:active,
+  .menuLink:focus,
+  .menuLink:hover {
     font-weight: 700;
     color: white;
   }
-
 } /* closing bracket for the @layer */
 
-
 @layer utilities {
-  
-  .blur{
+  .blur {
     filter: blur(1.5px);
   }
 
-  .error404-link::before{
+  .error404-link::before {
     display: inline-block;
     margin: 2px 5px;
     content: " ";
@@ -144,7 +149,7 @@ html {
     height: 4px;
   }
 
-  .splash-link::after{
+  .splash-link::after {
     display: inline-block;
     margin: 2px 5px;
     content: " ";
@@ -159,15 +164,20 @@ html {
     border-radius: 50%;
     width: 148px;
     height: 148px;
-    background-color: #EEEEEE;
+    background-color: #eeeeee;
   }
 
-  .textbuttonField > p{
-    @apply text-sm leading-normal font-normal font-body py-4
+  .textbuttonField > p {
+    @apply text-sm leading-normal font-normal font-body py-4;
   }
 
-  .textbuttonField > h1, h2, h3, h4, h5, h6{
-    @apply mb-4
+  .textbuttonField > h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    @apply mb-4;
   }
 
   .border-outset {
@@ -178,12 +188,12 @@ html {
     content: url(../public/images/up-caret.svg);
   }
 
-  .skip-main{
-    @apply absolute w-px h-px -left-96
+  .skip-main {
+    @apply absolute w-px h-px -left-96;
   }
 
-  .skip-main:focus-within{
-    @apply absolute w-screen h-auto top-16 left-0 z-50 flex justify-center
+  .skip-main:focus-within {
+    @apply absolute w-screen h-auto top-16 left-0 z-50 flex justify-center;
   }
 
   /* Default page layout */
@@ -196,7 +206,7 @@ html {
       @apply mx-4;
     }
   }
-  
+
   @screen xs {
     .layout-container {
       @apply px-0;
@@ -208,20 +218,20 @@ html {
       @apply px-0;
     }
 
-    .textbuttonField > p{
-      @apply text-p
+    .textbuttonField > p {
+      @apply text-p;
     }
   }
-  
+
   @screen lg {
     .layout-container {
       @apply container mx-auto px-6;
     }
-    
+
     .circle-background {
       width: 120px;
       height: 120px;
-    } 
+    }
   }
 
   @screen xl {
@@ -245,7 +255,25 @@ html {
   }
 }
 
+.flex-container {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  margin-right: 20px;
+}
+
+/* small screen */
+@media only screen and (max-width: 400px) {
+  .layout-container {
+    flex-direction: column;
+  }
+
+  .flex-container {
+    flex-direction: row;
+    margin-right: 0;
+  }
+}
 
 .footerBackground {
-  background:#26374a url(../public/images/landscape.png) no-repeat right bottom;
+  background: #26374a url(../public/images/landscape.png) no-repeat right bottom;
 }


### PR DESCRIPTION
# Description

[LJ-271-SC Labs banner at top of site](https://lj-decd.atlassian.net/browse/LJ-271?atlOrigin=eyJpIjoiYTYwNTUzNzg3NzFiNDUzMDkwODdkNDg5NTA4NmJmZGMiLCJwIjoiaiJ9)

I modified the existing `PhaseBanner` component to look like the SCLabs banner from the figma designs (shown [here](https://www.figma.com/file/3HABNGmlJkUnZ4D3tHvLcc/LifeJourneysDesign-NCJprototype?node-id=1539%3A3807)).
For the time being the feedback portion of the component has been de-scoped.

I also slightly changed the styling of the province selector dropdown (changed border color and removed rounded border as per designs)

## Test Instructions

1. Pull in branch
2. Type `npm run dev`
3. Alternate between mobile and desktop screen sizes to see the banner change

## Meets Definition of Done

- [x] Meets design spec
- [x] unit tests are included
