### PR TITLE
LJ-378 Saving the region to a cookie

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -25,6 +25,13 @@ export default function lifejourney({ journeysData }) {
     } else {
       alert("Sorry, browser does not support geolocation!");
     }
+
+    console.log("current region saved = ", region.current);
+    console.log("region cookie = ", window.localStorage.getItem("region"));
+    if (region.current !== window.localStorage.getItem("region")) {
+      region.current = window.localStorage.getItem("region");
+    }
+
     async function getGeo() {
       const res = await fetch("https://ipapi.co/json/");
       const data = await res.json();
@@ -41,6 +48,7 @@ export default function lifejourney({ journeysData }) {
 
   function onChangeFunc(optionSelected) {
     region.current = optionSelected;
+    window.localStorage.setItem("region", optionSelected);
     forceUpdate();
   }
 


### PR DESCRIPTION
# Description

LJ-378 Extra Text. most noticeable when users selected quebec and navigates away then return

On province change the value is saved to a cookie, 
**On navigating away and returning** the drop down selected value could be different than the default which is Canada (eg: Quebec) however the value _region.current_ would be the default CAN instead of the province selected (eg: QC). 

the change uses the value of the cookie in the storage to override _region.current_ so that the visually selected option matches the value of the region used to display Quebec card text.

## Test Instructions

1. Download and test selecting quebec and navigating away and returning to the page using the browser back button


## Meets Definition of Done

- [x] Meets design spec
- [ ] unit tests are included
