### PR TITLE
fixed report a problem and resource links

### DIFF
--- a/components/atoms/Details.js
+++ b/components/atoms/Details.js
@@ -4,7 +4,7 @@ import PropTypes from "prop-types";
  * Dropdown component
  */
 
-export default function DropDown(props) {
+export default function Details(props) {
   return (
     <details>
       <summary className="h-auto xl:h-46px max-w-350px w-full bg-details-button-gray focus:ring-black focus:ring-inset-1 focus:ring-2 active:bg-details-button-active-gray hover:bg-details-button-hover-gray rounded py-12px px-5px font-body text-sm text-center text-custom-blue-reportButton list-item cursor-pointer border border-outset border-details-button-gray">
@@ -17,7 +17,7 @@ export default function DropDown(props) {
   );
 }
 
-DropDown.propTypes = {
+Details.propTypes = {
   /**
    * Text that will show on the drop down
    */

--- a/components/atoms/Details.test.js
+++ b/components/atoms/Details.test.js
@@ -1,25 +1,23 @@
 import { render, act, screen } from "@testing-library/react";
 import "@testing-library/jest-dom/extend-expect";
-import DropDown from "./DropDown";
+import Details from "./Details";
 import { axe, toHaveNoViolations } from "jest-axe";
 
 expect.extend(toHaveNoViolations);
 
-const dropDownText = "Drop it like it's hot";
-const dropDownId = "testDropDownID";
+const detailsText = "Drop it like it's hot";
+const detailsId = "testDropDownID";
 
 describe("DropDown tests", () => {
   it("renders DropDown", () => {
     const primary = act(() => {
-      render(<DropDown text={dropDownText} id={dropDownId} />);
+      render(<Details text={detailsText} id={detailsId} />);
     });
     expect(primary).toBeTruthy();
   });
 
   it("has no a11y violations", async () => {
-    const { container } = render(
-      <DropDown text={dropDownText} id={dropDownId} />
-    );
+    const { container } = render(<Details text={detailsText} id={detailsId} />);
     const results = await axe(container);
     expect(results).toHaveNoViolations();
   });

--- a/components/atoms/MultiTextField.js
+++ b/components/atoms/MultiTextField.js
@@ -14,6 +14,7 @@ export function MultiTextField(props) {
       >
         {props.label}
       </label>
+      <p className="pb-4 pt-2 text-xs sm:text-sm">{props.disclaimer}</p>
       <textarea
         className="text-input font-body w-full min-h-40px rounded shadow-sm text-form-input-gray border border-form-input-border-gray py-6px px-12px"
         id={props.id}
@@ -90,4 +91,8 @@ MultiTextField.propTypes = {
    * call back for when the value of the multi text field changes
    */
   onChange: PropTypes.func,
+  /**
+   * Disclaimer text to go above the text field
+   */
+  disclaimer: PropTypes.string,
 };

--- a/components/atoms/ReportProblem.js
+++ b/components/atoms/ReportProblem.js
@@ -1,4 +1,4 @@
-import DropDown from "./DropDown";
+import Details from "./Details";
 import { ActionButton } from "./ActionButton";
 import { OptionalTextField } from "../molecules/OptionalTextField";
 import { useState } from "react";
@@ -39,7 +39,7 @@ export default function ReportProblem() {
   };
 
   return (
-    <DropDown text={t.reportAProblemButtonString}>
+    <Details text={t.reportAProblemButtonString}>
       {submitted ? (
         <>
           <h2 className="text-base font-body mb-4">
@@ -49,156 +49,156 @@ export default function ReportProblem() {
             {t.reportAProblemYouWillNotBeContacted}
           </p>
           <a
-            className="block text-sm font-body hover:text-custom-blue-link focus:text-custom-blue-link focus:underline text-canada-footer-font"
+            className="underline text-sm font-body hover:text-custom-blue-link focus:text-custom-blue-link text-canada-footer-font"
             href="mailto:experience@servicecanada.gc.ca"
           >
             experience@servicecanada.gc.ca
           </a>
         </>
       ) : (
-        <form className="w-full" action="#" onSubmit={onSubmitHandler}>
-          <input type="hidden" id="language" name="language" value={language} />
-          <fieldset>
-            <legend className="text-h3 text-center font-normal mb-6">
-              {t.reportAProblemCheckAllThatApply}
-            </legend>
-            <OptionalTextField
-              checkBoxId="incorrectInformationCheckBox"
-              textFieldId="incorrectInformationTextField"
-              checkBoxName="incorrect_information"
-              textFieldName="incorrect_information_details"
-              checkBoxLabel={t.reportAProblemIncorrectInformation}
-              textFieldLabel={t.reportAProblemProvideMoreDetails}
-              uncontrolled={true}
-              multiText={true}
-              textLabelBold={true}
-              wrap="hard"
-              maxLength={750}
-            />
-            <OptionalTextField
-              checkBoxId="unclearInformationCheckBox"
-              textFieldId="unclearInformationTextField"
-              checkBoxName="unclear_information"
-              textFieldName="unclear_information_details"
-              checkBoxLabel={t.reportAProblemUnclearInformation}
-              textFieldLabel={t.reportAProblemProvideMoreDetails}
-              uncontrolled={true}
-              multiText={true}
-              textLabelBold={true}
-              wrap="hard"
-              maxLength={750}
-            />
-            <OptionalTextField
-              checkBoxId="infoNotFoundCheckBox"
-              textFieldId="infoNotFoundTextField"
-              checkBoxName="info_not_found"
-              textFieldName="info_not_found_details"
-              checkBoxLabel={t.reportAProblemDidNotFindWhatYoureLookingFor}
-              textFieldLabel={t.reportAProblemProvideMoreDetails}
-              uncontrolled={true}
-              multiText={true}
-              textLabelBold={true}
-              wrap="hard"
-              maxLength={750}
-            />
-            <OptionalTextField
-              checkBoxId="adaptiveTechnologyCheckBox"
-              textFieldId="adaptiveTechnologyTextField"
-              checkBoxName="adaptive_technology"
-              textFieldName="adaptive_technology_details"
-              checkBoxLabel={
-                t.reportAProblemPageDoesNotWorkWithAdaptiveTechnology
-              }
-              textFieldLabel={t.reportAProblemProvideMoreDetails}
-              uncontrolled={true}
-              multiText={true}
-              textLabelBold={true}
-              wrap="hard"
-              maxLength={750}
-            />
-            <OptionalTextField
-              checkBoxId="privacyIssuesCheckBox"
-              textFieldId="privacyIssuesTextField"
-              checkBoxName="privacy_issues"
-              textFieldName="privacy_issues_details"
-              checkBoxLabel={t.reportAProblemYoureWorriedAboutYourPrivacy}
-              textFieldLabel={t.reportAProblemProvideMoreDetails}
-              uncontrolled={true}
-              multiText={true}
-              textLabelBold={true}
-              wrap="hard"
-              maxLength={750}
-            />
-            <OptionalTextField
-              checkBoxId="noWhereElseToGoCheckBox"
-              textFieldId="noWhereElseToGoTextField"
-              checkBoxName="no_where_else_to_go"
-              textFieldName="no_where_else_to_go_details"
-              checkBoxLabel={t.reportAProblemNoWhereElseToGo}
-              textFieldLabel={t.reportAProblemProvideMoreDetails}
-              uncontrolled={true}
-              multiText={true}
-              textLabelBold={true}
-              wrap="hard"
-              maxLength={750}
-            />
-            <OptionalTextField
-              checkBoxId="otherCheckBox"
-              textFieldId="otherTextField"
-              checkBoxName="other"
-              textFieldName="other_details"
-              checkBoxLabel={t.reportAProblemOther}
-              textFieldLabel={t.reportAProblemProvideMoreDetails}
-              uncontrolled={true}
-              multiText={true}
-              textLabelBold={true}
-              wrap="hard"
-              maxLength={750}
-            />
-          </fieldset>
-
-          <ul className="list-outside list-disc px-6 py-2">
-            <li className="text-xxs sm:text-sm font-body my-4 leading-tight sm:leading-6">
+        <>
+          <h2 className="sm:text-h3-tall text-h5 font-display">
+            {t.reportAProblemTitle}
+          </h2>
+          <ul className="list-outside list-disc px-6 pb-2">
+            <li className="text-xs sm:text-sm font-body my-4 leading-tight sm:leading-6">
               <b>{t.reportAProblemNoReply}</b>
               {t.reportAProblemEnquiries}
               <a
-                className="block text-xxs sm:text-sm font-body hover:underline hover:text-custom-blue-link focus:text-custom-blue-link focus:underline text-canada-footer-font"
+                className="block text-xs sm:text-sm font-body hover:underline hover:text-custom-blue-link focus:text-custom-blue-link focus:underline text-canada-footer-font"
                 href="mailto:experience@servicecanada.gc.ca"
               >
                 experience@servicecanada.gc.ca
               </a>
             </li>
-            <li className="text-xxs sm:text-sm font-body my-4 leading-tight sm:leading-6">
-              <b>{t.reportAProblemNoPersonalInfo}</b>,&nbsp;
-              {t.reportAProblemNoPersonalInfoDetails}
-            </li>
-            <li className="text-xxs sm:text-sm font-body my-4 leading-tight sm:leading-6">
-              <b>{t.reportAProblemMoreInfo}</b>,&nbsp;
-              {t.reportAProblemMoreInfoDetails}&nbsp;
-              <a
-                className="text-xxs sm:text-sm font-body hover:text-custom-blue-link hover:underline focus:text-custom-blue-link focus:underline text-canada-footer-font"
-                href={t.reportAProblemMoreInfoLink}
-              >
-                {t.reportAProblemMoreInfoLinkText}
-              </a>
+            <li className="text-xs sm:text-sm font-body my-2 leading-tight sm:leading-6">
+              <b>{t.reportAProblemConfidential}</b>
             </li>
           </ul>
           <a
-            className="block text-xs sm:text-sm font-body hover:text-custom-blue-link focus:text-custom-blue-link text-canada-footer-font my-4 underline"
+            className="block text-xs sm:text-sm font-body hover:text-custom-blue-link focus:text-custom-blue-link text-canada-footer-font mb-6 underline"
             href={t.reportAProblemPrivacyStatementLink}
           >
             {t.reportAProblemPrivacyStatement}
           </a>
-          <ActionButton
-            id="submit"
-            className="rounded"
-            type="submit"
-            custom="bg-custom-blue-dark pb-1.5 pt-1.5 rounded text-white hover:bg-custom-blue-canadaLight border border-custom-blue-dark focus:ring-1 focus:ring-black focus:ring-offset-1 focus:bg-custom-blue-canadaLight active:bg-custom-blue-reportButtonActive"
-          >
-            Submit
-          </ActionButton>
-        </form>
+          <form className="w-full" action="#" onSubmit={onSubmitHandler}>
+            <input type="hidden" id="language" name="language" />
+            <fieldset>
+              <legend className="text-base sm:text-p font-body font-normal mb-6">
+                {t.reportAProblemCheckAllThatApply}
+              </legend>
+              <OptionalTextField
+                checkBoxId="incorrectInformationCheckBox"
+                textFieldId="incorrectInformationTextField"
+                checkBoxName="incorrect_information"
+                textFieldName="incorrect_information_details"
+                checkBoxLabel={t.reportAProblemIncorrectInformation}
+                textFieldLabel={t.reportAProblemProvideMoreDetails}
+                uncontrolled={true}
+                multiText={true}
+                textLabelBold={true}
+                wrap="hard"
+                maxLength={750}
+                disclaimer={t.reportAProblemNoPersonalInfo}
+              />
+              <OptionalTextField
+                checkBoxId="unclearInformationCheckBox"
+                textFieldId="unclearInformationTextField"
+                checkBoxName="unclear_information"
+                textFieldName="unclear_information_details"
+                checkBoxLabel={t.reportAProblemUnclearInformation}
+                textFieldLabel={t.reportAProblemProvideMoreDetails}
+                uncontrolled={true}
+                multiText={true}
+                textLabelBold={true}
+                wrap="hard"
+                maxLength={750}
+                disclaimer={t.reportAProblemNoPersonalInfo}
+              />
+              <OptionalTextField
+                checkBoxId="infoNotFoundCheckBox"
+                textFieldId="infoNotFoundTextField"
+                checkBoxName="info_not_found"
+                textFieldName="info_not_found_details"
+                checkBoxLabel={t.reportAProblemDidNotFindWhatYoureLookingFor}
+                textFieldLabel={t.reportAProblemProvideMoreDetails}
+                uncontrolled={true}
+                multiText={true}
+                textLabelBold={true}
+                wrap="hard"
+                maxLength={750}
+                disclaimer={t.reportAProblemNoPersonalInfo}
+              />
+              <OptionalTextField
+                checkBoxId="adaptiveTechnologyCheckBox"
+                textFieldId="adaptiveTechnologyTextField"
+                checkBoxName="adaptive_technology"
+                textFieldName="adaptive_technology_details"
+                checkBoxLabel={
+                  t.reportAProblemPageDoesNotWorkWithAdaptiveTechnology
+                }
+                textFieldLabel={t.reportAProblemProvideMoreDetails}
+                uncontrolled={true}
+                multiText={true}
+                textLabelBold={true}
+                wrap="hard"
+                maxLength={750}
+                disclaimer={t.reportAProblemNoPersonalInfo}
+              />
+              <OptionalTextField
+                checkBoxId="privacyIssuesCheckBox"
+                textFieldId="privacyIssuesTextField"
+                checkBoxName="privacy_issues"
+                textFieldName="privacy_issues_details"
+                checkBoxLabel={t.reportAProblemYoureWorriedAboutYourPrivacy}
+                textFieldLabel={t.reportAProblemProvideMoreDetails}
+                uncontrolled={true}
+                multiText={true}
+                textLabelBold={true}
+                wrap="hard"
+                maxLength={750}
+                disclaimer={t.reportAProblemNoPersonalInfo}
+              />
+              <OptionalTextField
+                checkBoxId="noWhereElseToGoCheckBox"
+                textFieldId="noWhereElseToGoTextField"
+                checkBoxName="no_where_else_to_go"
+                textFieldName="no_where_else_to_go_details"
+                checkBoxLabel={t.reportAProblemNoWhereElseToGo}
+                textFieldLabel={t.reportAProblemProvideMoreDetails}
+                uncontrolled={true}
+                multiText={true}
+                textLabelBold={true}
+                wrap="hard"
+                maxLength={750}
+                disclaimer={t.reportAProblemNoPersonalInfo}
+              />
+              <OptionalTextField
+                checkBoxId="otherCheckBox"
+                textFieldId="otherTextField"
+                checkBoxName="other"
+                textFieldName="other_details"
+                checkBoxLabel={t.reportAProblemOther}
+                textFieldLabel={t.reportAProblemProvideMoreDetails}
+                uncontrolled={true}
+                multiText={true}
+                textLabelBold={true}
+                wrap="hard"
+                maxLength={750}
+                disclaimer={t.reportAProblemNoPersonalInfo}
+              />
+            </fieldset>
+            <ActionButton
+              id="submit"
+              className="rounded block"
+              type="submit"
+              custom="bg-custom-blue-dark pb-1.5 pt-1.5 rounded text-white hover:bg-custom-blue-canadaLight border border-custom-blue-dark focus:ring-1 focus:ring-black focus:ring-offset-1 focus:bg-custom-blue-canadaLight active:bg-custom-blue-reportButtonActive"
+            >
+              {t.reportAProblemSubmit}
+            </ActionButton>
+          </form>
+        </>
       )}
-    </DropDown>
+    </Details>
   );
 }

--- a/components/atoms/ResourceLink.js
+++ b/components/atoms/ResourceLink.js
@@ -16,7 +16,7 @@ export default function ResourceLink(props) {
     .replace(/\s/g, "+");
 
   return props.isProvincialLink ? (
-    <div className="flex flex-wrap">
+    <div className="sm:block flex flex-wrap">
       {filteredLinks.sites.map(({ label, link }) => (
         <div key={link} className={props.className}>
           <a

--- a/components/molecules/OptionalTextField.js
+++ b/components/molecules/OptionalTextField.js
@@ -47,6 +47,7 @@ export function OptionalTextField(props) {
             onChange={
               props.onTextFieldChange ? props.onTextFieldChange : () => {}
             }
+            disclaimer={props.disclaimer}
           />
         ) : (
           <TextField
@@ -171,4 +172,8 @@ OptionalTextField.propTypes = {
    * whether or not to spellcheck for the multi text field
    */
   spellCheck: PropTypes.bool,
+  /**
+   * Disclaimer text to go above the text field
+   */
+  disclaimer: PropTypes.string,
 };

--- a/locales/en.js
+++ b/locales/en.js
@@ -189,6 +189,7 @@ export default {
     "We often lean on those closest to us for advice. Find and build your support close to where you live.",
 
   //Report a problem
+  reportAProblemTitle: "Report a problem or mistake on this page",
   reportAProblemButtonString: "Report a problem on this page",
   reportAProblemCheckAllThatApply: "Please select all that apply:",
   reportAProblemIncorrectInformation: "Incorrect Information",
@@ -203,21 +204,17 @@ export default {
   reportAProblemOther: "Other",
   reportAProblemProvideMoreDetails: "Provide more details (optional)",
   reportAProblemNoReply: "You will not receive a reply. ",
-  reportAProblemEnquiries: "For enquiries, please contact",
-  reportAProblemNoPersonalInfo: "Do not include any personal information",
-  reportAProblemNoPersonalInfoDetails:
-    "such as your name, social insurance number (SIN), home or business address or any case or file numbers",
-  reportAProblemMoreInfo: "For more information about this tool",
-  reportAProblemMoreInfoDetails: "please refer to our",
-  reportAProblemMoreInfoLink:
-    "https://www.canada.ca/en/transparency/terms.html",
-  reportAProblemMoreInfoLinkText: "terms and conditions",
+  reportAProblemEnquiries: "For enquiries, please contact ",
+  reportAProblemConfidential: "Your feedback will be condifential",
+  reportAProblemNoPersonalInfo:
+    "Do not include any personal, medical, or financial details, such as your name, social insurance number (SIN), home or business address, phone number or any case or file numbers.",
   reportAProblemThankYouForYourHelp: "Thank you for your help!",
   reportAProblemYouWillNotBeContacted:
-    "You will not receive a reply. For enquiries, please contact us at",
+    "You will not receive a reply. For enquiries, please contact us at ",
   reportAProblemPrivacyStatement: "Privacy statement",
   reportAProblemPrivacyStatementLink:
     "https://www.canada.ca/en/transparency/privacy.html",
+  reportAProblemSubmit: "Submit",
 
   //Landing Page Title Section
   landingPageTitle: "Get Information About a Life Journey",

--- a/locales/fr.js
+++ b/locales/fr.js
@@ -194,6 +194,7 @@ export default {
     "Nous nous appuyons souvent sur les personnes les plus proches de nous pour obtenir des conseils. Trouvez et construisez votre réseau de soutien près de chez vous.",
 
   //Report a problem
+  reportAProblemTitle: "Signaler un problème ou une erreur sur cette page",
   reportAProblemButtonString: "Signaler un problème sur cette page",
   reportAProblemCheckAllThatApply:
     "Veuillez sélectionner tous les éléments qui s'appliquent:",
@@ -211,19 +212,16 @@ export default {
   reportAProblemNoReply: "Vous ne recevrez pas de réponse. ",
   reportAProblemEnquiries:
     "Pour toute demande de renseignements, veuillez contacter",
-  reportAProblemNoPersonalInfo: "N'incluez pas d'informations personnelles",
-  reportAProblemNoPersonalInfoDetails:
-    "tels que votre nom, votre numéro d'assurance sociale (NAS), votre adresse personnelle ou professionnelle ou tout numéro de dossier ou d'affaire",
-  reportAProblemMoreInfo: "Pour plus d'informations sur cet outil",
-  reportAProblemMoreInfoDetails: "veuillez vous référer à nos",
-  reportAProblemMoreInfoLink: "https://www.canada.ca/fr/transparence/avis.html",
-  reportAProblemMoreInfoLinkText: "termes et conditions",
+  reportAProblemConfidential: "Vos commentaires sont confidentiels",
+  reportAProblemNoPersonalInfo:
+    "Ne pas inclure de renseignements personnels, médicaux ou financiers, comme par exemple, un numéro d'assurance sociale (NAS), une adresse de domicile ou de lieu de travail, un numéro de téléphone ou numéro de dossier.",
   reportAProblemThankYouForYourHelp: "Merci pour votre aide!",
   reportAProblemYouWillNotBeContacted:
     "Vous ne recevrez pas de réponse. Pour toute demande de renseignements, veuillez nous contacter à",
   reportAProblemPrivacyStatement: "Déclaration de confidentialité",
   reportAProblemPrivacyStatementLink:
     "https://www.canada.ca/fr/transparence/confidentialite.html",
+  reportAProblemSubmit: "Soumettre",
 
   //Landing Page Title Section
   landingPageTitle: "Obtenir Des Informations Sur Un Parcours De Vie",

--- a/pages/index.js
+++ b/pages/index.js
@@ -107,7 +107,7 @@ export default function lifejourney({ journeysData }) {
 
           {/* Connect to Local Resources */}
 
-          <div className="container flex flex-col w-full md:w-32 md:flex-row mt-4">
+          <div className="container flex flex-col w-full md:w-1/2 md:flex-row mt-4">
             <div>
               <h3 className="text-h4 mb-4 font-bold font-display">
                 {t.getConnected}


### PR DESCRIPTION
# Description

This PR addresses the report a problem issues that were pointed out on the accessibility audit. This also fixes the resource links so that they are each on their own line as well as the breakpoint being closer to the middle of the screen as per Steph's request.

For the report a problem component, I am following the approved design that Alpha is following, which can be seen here:
![Report_a_problem_or_mistake_on_this_page](https://user-images.githubusercontent.com/71025360/128391906-779f3708-1542-4326-967c-b2fbbc4da70a.png)

## Test Instructions

1. Pull in branch
2. Type `npm run dev`
3. Open the `Report a Problem` element at the bottom of the page, click each of the boxes
4. Select Quebec from the province dropdown and try the site at different resolutions to confirm that the links are each on their own line

## Meets Definition of Done

- [x] Meets design spec
- [x] unit tests are included
