### PR TITLE
LJ-402 added french translation to skip to content aria-label

### DIFF
--- a/components/organisms/Header.js
+++ b/components/organisms/Header.js
@@ -41,7 +41,7 @@ export function Header({ bannerText, breadcrumbItems }) {
 
   return (
     <>
-      <nav className="hidden" aria-label="skip-main">
+      <nav className="hidden" aria-label={t.skipToMainContent}>
         <a
           id="skipToMainContent"
           className="bg-custom-blue-dark text-white py-1 px-2 hover:bg-gray-dark"


### PR DESCRIPTION
# Description

[LJ-402] On the French page, there is some text that is still in English. Examples: - Language toggle link. (Same issue on the English page) - Text in the aria-label attribute that is read to screen reader users in the hidden skip nav. <nav class="hidden" aria-label="skip-main">

## Test Instructions

1. Download and run, use inspect to verify page content in french 

## Meets Definition of Done

- [x] Meets design spec
- [ ] unit tests are included


[LJ-402]: https://lj-decd.atlassian.net/browse/LJ-402