### PR TITLE
Moved banner into main content, changed links

### DIFF
--- a/components/atoms/Banner.js
+++ b/components/atoms/Banner.js
@@ -13,7 +13,10 @@ export const Banner = ({ headline }) => {
         className="bg-cover bg-no-repeat xxs:bg-center bg-right h-full lg:bg-banner-img md:pt-16 lg:pt-4 lg:py-7 xxs:bg-banner-img-mobile"
       >
         <div className="lg:container xxl:px-8 lg:px-4 xxl:mx-auto xxs:pl-4 lg:py-14 xxs:pt-8">
-          <h1 className="lg:text-h1l text-h1 font-bold font-display py-20 lg:py-9 break-words xxs:pb-4">
+          <h1
+            id="wb-cont"
+            className="lg:text-h1l text-h1 font-bold font-display py-20 lg:py-9 break-words xxs:pb-4"
+          >
             {headline}
           </h1>
         </div>

--- a/components/layout.js
+++ b/components/layout.js
@@ -2,6 +2,7 @@ import propTypes from "prop-types";
 import { Meta } from "./atoms/Meta";
 import { Header } from "./organisms/Header";
 import { Footer } from "./organisms/Footer";
+import Banner from "./atoms/Banner";
 import "@fortawesome/fontawesome-svg-core/styles.css";
 import { config } from "@fortawesome/fontawesome-svg-core";
 config.autoAddCss = false; /* eslint-disable import/first */
@@ -9,8 +10,6 @@ config.autoAddCss = false; /* eslint-disable import/first */
 export default function Layout({
   children,
   title,
-  locale,
-  bannerTitle,
   bannerText,
   breadcrumbItems,
 }) {
@@ -19,13 +18,11 @@ export default function Layout({
       <Meta title={title} />
 
       <div className="overflow-x-hidden">
-        <Header
-          bannerTitle={bannerTitle}
-          bannerText={bannerText}
-          breadcrumbItems={breadcrumbItems}
-        />
+        <Header breadcrumbItems={breadcrumbItems} />
 
         <main>
+          {/* Display a banner when requested */}
+          {bannerText ? <Banner headline={bannerText} /> : ""}
           <div>{children}</div>
         </main>
 

--- a/components/molecules/Breadcrumb.js
+++ b/components/molecules/Breadcrumb.js
@@ -1,15 +1,23 @@
 import propTypes from "prop-types";
 import Link from "next/link";
+import { useContext } from "react";
+import { LanguageContext } from "../../context/languageProvider";
+import en from "../../locales/en";
+import fr from "../../locales/fr";
 
 /**
  *  Breadcrumb component
  */
 export function Breadcrumb(props) {
+  const { items } = useContext(LanguageContext);
+  const language = items.language;
+  const t = language === "en" ? en : fr;
+
   return (
     <nav aria-label="breadcrumbs">
       <ul className="block text-custom-blue-dark text-sm font-body">
         <li className="inline-block min-w-0 max-w-full">
-          <Link href="https://www.canada.ca/">
+          <Link href={t.gocLink}>
             <a className="hover:text-custom-blue-link visited:text-purple-700 underline">
               Canada.ca
             </a>

--- a/components/molecules/Breadcrumb.test.js
+++ b/components/molecules/Breadcrumb.test.js
@@ -2,22 +2,31 @@ import { render, act } from "@testing-library/react";
 import "@testing-library/jest-dom/extend-expect";
 import { axe, toHaveNoViolations } from "jest-axe";
 import { Breadcrumb } from "./Breadcrumb";
+import { LanguageContext } from "../../context/languageProvider";
 
 expect.extend(toHaveNoViolations);
 
 const text = "This is a crumb of bread";
 
 describe("breadcrumb", () => {
+  const contextValue = { items: { language: "en" } };
+
   it("renders breadcrumb", () => {
     const primary = act(() => {
-      render(<Breadcrumb items={[{ text: text, link: "/" }]} />);
+      render(
+        <LanguageContext.Provider value={contextValue}>
+          <Breadcrumb items={[{ text: text, link: "/" }]} />
+        </LanguageContext.Provider>
+      );
     });
     expect(primary).toBeTruthy();
   });
 
   it("has no a11y violations", async () => {
     const { container } = render(
-      <Breadcrumb items={[{ text: text, link: "/" }]} />
+      <LanguageContext.Provider value={contextValue}>
+        <Breadcrumb items={[{ text: text, link: "/" }]} />
+      </LanguageContext.Provider>
     );
 
     const results = await axe(container);

--- a/components/organisms/Header.js
+++ b/components/organisms/Header.js
@@ -2,7 +2,6 @@ import propTypes from "prop-types";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { PhaseBanner } from "../atoms/PhaseBanner";
-import Banner from "../atoms/Banner";
 import { Breadcrumb } from "../molecules/Breadcrumb";
 
 import { useEffect, useContext } from "react";
@@ -11,7 +10,7 @@ import { LanguageContext } from "../../context/languageProvider";
 import en from "../../locales/en";
 import fr from "../../locales/fr";
 
-export function Header({ bannerText, breadcrumbItems }) {
+export function Header({ breadcrumbItems }) {
   const { items } = useContext(LanguageContext);
   const changeLanguage = items.changeLanguage;
 
@@ -67,19 +66,21 @@ export function Header({ bannerText, breadcrumbItems }) {
 
         <div className="layout-container flex-col flex lg:flex lg:flex-row justify-between mt-2">
           <div className="flex flex-row justify-between items-center lg:mt-7 mt-1.5">
-            <img
-              className="h-5 w-auto xs:h-6 sm:h-8 md:h-8 lg:h-7 xl:h-8"
-              src={
-                language === "en"
-                  ? "/images/sig-blk-en.svg"
-                  : "/images/sig-blk-fr.svg"
-              }
-              alt={
-                language === "en"
-                  ? "Symbol of the Government of Canada"
-                  : "Gouvernement du Canada"
-              }
-            />
+            <a href={t.gocLink}>
+              <img
+                className="h-5 w-auto xs:h-6 sm:h-8 md:h-8 lg:h-7 xl:h-8"
+                src={
+                  language === "en"
+                    ? "/images/sig-blk-en.svg"
+                    : "/images/sig-blk-fr.svg"
+                }
+                alt={
+                  language === "en"
+                    ? "Symbol of the Government of Canada"
+                    : "Gouvernement du Canada"
+                }
+              />
+            </a>
 
             {/* Language selector for small screens */}
             <Link key={language} href={router.asPath} locale={language}>
@@ -120,9 +121,6 @@ export function Header({ bannerText, breadcrumbItems }) {
         <div className="layout-container my-2">
           <Breadcrumb items={breadcrumbItems} />
         </div>
-
-        {/* Display a banner when requested */}
-        {bannerText ? <Banner headline={bannerText} /> : ""}
       </header>
     </>
   );


### PR DESCRIPTION
# Description

[LJ-393 place main heading inside the main region of the page](https://lj-decd.atlassian.net/browse/LJ-393?atlOrigin=eyJpIjoiYjFjY2QyYTQxMWEzNGVjMzhhMGFkNWI0ZjEyMDBiMDUiLCJwIjoiaiJ9)

This PR moves the banner into the the page's main content, rather than being a part of the header. Sidra brought to my attention that the GoC logo at the top of the screen does not link to Canada.ca's homepage as it should (this is also the functionality on Alpha's site, though they link to the splash page, which is actually incorrect flow). That said, I've changed the link for the breadcrumb and the GoC logo to be [https://www.canada.ca/en.html](https://www.canada.ca/en.html) for English and [https://www.canada.ca/fr.html](https://www.canada.ca/fr.html) for French.

## Test Instructions

1. Pull in branch
2. Type `npm run dev`
3. Mouse over the GoC logo and breadcrumb link to ensure the correct link is shown for both languages

## Meets Definition of Done

- [x] Meets design spec
- [x] unit tests are included
