### PR TITLE
Changed icon, added sr-only text

### DIFF
--- a/components/atoms/ResourceLink.js
+++ b/components/atoms/ResourceLink.js
@@ -3,21 +3,13 @@ import sitesEN from "../../pages/api/provincialSitesEN";
 import sitesFR from "../../pages/api/provincialSitesFR";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faExternalLinkAlt } from "@fortawesome/free-solid-svg-icons";
-import { useContext } from "react";
-import { LanguageContext } from "../../context/languageProvider";
-import en from "../../locales/en";
-import fr from "../../locales/fr";
 
 /**
  *  This component creates a link to a provincial website based on the user's region OR a google search query with the provided text
  */
 
 export default function ResourceLink(props) {
-  const { items } = useContext(LanguageContext);
-  const language = items.language;
-  const t = language === "en" ? en : fr;
-
-  const links = language === "en" ? sitesEN : sitesFR;
+  const links = props.language === "en" ? sitesEN : sitesFR;
   const filteredLinks = links.find((link) => link.value === props.region);
   const googleSearch = "https://google.ca/search?q="
     .concat(props.text)
@@ -35,7 +27,7 @@ export default function ResourceLink(props) {
             rel="noopener noreferrer"
           >
             {label}
-            <span className="sr-only">{t.newWindow}</span>
+            <span className="sr-only">{props.srOnly}</span>
           </a>
           <span className="pl-1">
             <FontAwesomeIcon icon={faExternalLinkAlt} size="sm" />
@@ -54,7 +46,7 @@ export default function ResourceLink(props) {
           href={googleSearch}
         >
           {props.text}
-          <span className="sr-only">{t.newWindow}</span>
+          <span className="sr-only">{props.srOnly}</span>
         </a>
         <span className="pl-1">
           <FontAwesomeIcon icon={faExternalLinkAlt} size="sm" />
@@ -71,6 +63,10 @@ ResourceLink.defaultProps = {
 };
 
 ResourceLink.propTypes = {
+  /**
+   * The language of the page to show, required for provincial link
+   */
+  language: PropTypes.string,
   /**
    * Identify which region user is in to determine which page to show, required for provincial link
    */
@@ -91,4 +87,8 @@ ResourceLink.propTypes = {
    * CSS overrides for the element
    */
   className: PropTypes.string,
+  /**
+   * Screen Reader Text
+   */
+  srOnly: PropTypes.string,
 };

--- a/components/atoms/ResourceLink.js
+++ b/components/atoms/ResourceLink.js
@@ -2,14 +2,22 @@ import PropTypes from "prop-types";
 import sitesEN from "../../pages/api/provincialSitesEN";
 import sitesFR from "../../pages/api/provincialSitesFR";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faArrowRight } from "@fortawesome/free-solid-svg-icons";
+import { faExternalLinkAlt } from "@fortawesome/free-solid-svg-icons";
+import { useContext } from "react";
+import { LanguageContext } from "../../context/languageProvider";
+import en from "../../locales/en";
+import fr from "../../locales/fr";
 
 /**
  *  This component creates a link to a provincial website based on the user's region OR a google search query with the provided text
  */
 
 export default function ResourceLink(props) {
-  const links = props.language === "en" ? sitesEN : sitesFR;
+  const { items } = useContext(LanguageContext);
+  const language = items.language;
+  const t = language === "en" ? en : fr;
+
+  const links = language === "en" ? sitesEN : sitesFR;
   const filteredLinks = links.find((link) => link.value === props.region);
   const googleSearch = "https://google.ca/search?q="
     .concat(props.text)
@@ -27,9 +35,10 @@ export default function ResourceLink(props) {
             rel="noopener noreferrer"
           >
             {label}
+            <span className="sr-only">{t.newWindow}</span>
           </a>
           <span className="pl-1">
-            <FontAwesomeIcon icon={faArrowRight} size="sm" />
+            <FontAwesomeIcon icon={faExternalLinkAlt} size="sm" />
           </span>
         </div>
       ))}
@@ -45,9 +54,10 @@ export default function ResourceLink(props) {
           href={googleSearch}
         >
           {props.text}
+          <span className="sr-only">{t.newWindow}</span>
         </a>
         <span className="pl-1">
-          <FontAwesomeIcon icon={faArrowRight} size="sm" />
+          <FontAwesomeIcon icon={faExternalLinkAlt} size="sm" />
         </span>
       </div>
     </div>
@@ -61,10 +71,6 @@ ResourceLink.defaultProps = {
 };
 
 ResourceLink.propTypes = {
-  /**
-   * The language of the page to show, required for provincial link
-   */
-  language: PropTypes.string,
   /**
    * Identify which region user is in to determine which page to show, required for provincial link
    */

--- a/components/atoms/ResourceLink.test.js
+++ b/components/atoms/ResourceLink.test.js
@@ -2,7 +2,6 @@ import { render, act } from "@testing-library/react";
 import "@testing-library/jest-dom/extend-expect";
 import { axe, toHaveNoViolations } from "jest-axe";
 import ResourceLink from "./ResourceLink";
-import { LanguageContext } from "../../context/languageProvider";
 
 expect.extend(toHaveNoViolations);
 
@@ -11,14 +10,14 @@ const region = "ON";
 const text = "Find hot singles in my area";
 
 describe("ResourceLink tests", () => {
-  const contextValue = { items: { language: "en" } };
-
   it("renders ResourceLink as a list of provincial links", () => {
     const primary = act(() => {
       render(
-        <LanguageContext.Provider value={contextValue}>
-          <ResourceLink region={region} isProvincialLink={true} />
-        </LanguageContext.Provider>
+        <ResourceLink
+          region={region}
+          isProvincialLink={true}
+          language={language}
+        />
       );
     });
     expect(primary).toBeTruthy();
@@ -27,9 +26,11 @@ describe("ResourceLink tests", () => {
   it("renders ResourceLink as a google search query link", () => {
     const primary = act(() => {
       render(
-        <LanguageContext.Provider value={contextValue}>
-          <ResourceLink text={text} isProvincialLink={false} />
-        </LanguageContext.Provider>
+        <ResourceLink
+          text={text}
+          isProvincialLink={false}
+          language={language}
+        />
       );
     });
     expect(primary).toBeTruthy();
@@ -37,9 +38,11 @@ describe("ResourceLink tests", () => {
 
   it("has no a11y violations", async () => {
     const { container } = render(
-      <LanguageContext.Provider value={contextValue}>
-        <ResourceLink region={region} isProvincialLink={true} />
-      </LanguageContext.Provider>
+      <ResourceLink
+        region={region}
+        isProvincialLink={true}
+        language={language}
+      />
     );
     const results = await axe(container);
 

--- a/components/atoms/ResourceLink.test.js
+++ b/components/atoms/ResourceLink.test.js
@@ -2,6 +2,7 @@ import { render, act } from "@testing-library/react";
 import "@testing-library/jest-dom/extend-expect";
 import { axe, toHaveNoViolations } from "jest-axe";
 import ResourceLink from "./ResourceLink";
+import { LanguageContext } from "../../context/languageProvider";
 
 expect.extend(toHaveNoViolations);
 
@@ -10,14 +11,14 @@ const region = "ON";
 const text = "Find hot singles in my area";
 
 describe("ResourceLink tests", () => {
+  const contextValue = { items: { language: "en" } };
+
   it("renders ResourceLink as a list of provincial links", () => {
     const primary = act(() => {
       render(
-        <ResourceLink
-          region={region}
-          language={language}
-          isProvincialLink={true}
-        />
+        <LanguageContext.Provider value={contextValue}>
+          <ResourceLink region={region} isProvincialLink={true} />
+        </LanguageContext.Provider>
       );
     });
     expect(primary).toBeTruthy();
@@ -25,18 +26,20 @@ describe("ResourceLink tests", () => {
 
   it("renders ResourceLink as a google search query link", () => {
     const primary = act(() => {
-      render(<ResourceLink text={text} isProvincialLink={false} />);
+      render(
+        <LanguageContext.Provider value={contextValue}>
+          <ResourceLink text={text} isProvincialLink={false} />
+        </LanguageContext.Provider>
+      );
     });
     expect(primary).toBeTruthy();
   });
 
   it("has no a11y violations", async () => {
     const { container } = render(
-      <ResourceLink
-        region={region}
-        language={language}
-        isProvincialLink={true}
-      />
+      <LanguageContext.Provider value={contextValue}>
+        <ResourceLink region={region} isProvincialLink={true} />
+      </LanguageContext.Provider>
     );
     const results = await axe(container);
 

--- a/locales/en.js
+++ b/locales/en.js
@@ -185,8 +185,7 @@ export default {
 
   //Connect to local resources
   getConnected: "Connect to local resources ",
-  getConnectedDescription:
-    "We often lean on those closest to us for advice. Find and build your support close to where you live.",
+  getConnectedDescription: "Find guidance and support close to where you live.",
 
   //Report a problem
   reportAProblemTitle: "Report a problem or mistake on this page",
@@ -228,4 +227,7 @@ export default {
     "You cannot apply for services or benefits through this test site. Parts of this site may not work and will change.",
   backToProject: "Back to projects",
   backToProjectsLink: "https://alpha.service.canada.ca/projects",
+
+  //Screen reader link text
+  newWindow: ", this link will open in a new window.",
 };

--- a/locales/fr.js
+++ b/locales/fr.js
@@ -190,8 +190,7 @@ export default {
 
   //Connect to local resources
   getConnected: "Connectez-vous aux ressources locales",
-  getConnectedDescription:
-    "Nous nous appuyons souvent sur les personnes les plus proches de nous pour obtenir des conseils. Trouvez et construisez votre réseau de soutien près de chez vous.",
+  getConnectedDescription: "Trouvez des conseils et l’appui près de chez vous.",
 
   //Report a problem
   reportAProblemTitle: "Signaler un problème ou une erreur sur cette page",
@@ -235,4 +234,7 @@ export default {
     "Vous ne pouvez pas demander de services ou de prestations par l’intermédiaire de ce site d’essai. Certaines parties du site pourraient ne pas fonctionner et seront modifiées.",
   backToProject: "Retourner aux projets",
   backToProjectsLink: "https://alpha.service.canada.ca/fr/projects",
+
+  //Screen reader link text
+  newWindow: ", ce lien va ouvrir dans une nouvelle fenêtre.",
 };

--- a/pages/api/provincialSitesFR.js
+++ b/pages/api/provincialSitesFR.js
@@ -1,17 +1,7 @@
 export default [
   {
     value: "CAN",
-    sites: [
-      {
-        label: "Je veux en savoir plus sur la santé des nouveau-nés",
-        link: "https://www.canada.ca/fr/sante-canada/services/soins-nourrissons.html",
-      },
-      {
-        label:
-          "Je veux m'informer sur les prestations de maternité et parentales de l'assurance-emploi",
-        link: "https://www.canada.ca/fr/services/prestations/ae/assurance-emploi-maternite-parentales.html",
-      },
-    ],
+    sites: [],
   },
   {
     value: "AB",

--- a/pages/index.js
+++ b/pages/index.js
@@ -116,15 +116,20 @@ export default function lifejourney({ journeysData }) {
                 text={t.moreInfoPrenatalClasses}
                 isProvincialLink={false}
                 id="prenatalClasses"
+                srOnly={t.newWindow}
               />
               <ResourceLink
                 text={t.moreInfoParentingNetworks}
                 isProvincialLink={false}
                 id="parentingNetworks"
+                srOnly={t.newWindow}
+                language={language}
               />
               <ResourceLink
                 region={region.current}
                 isProvincialLink={true}
+                srOnly={t.newWindow}
+                language={language}
               ></ResourceLink>
             </div>
           </div>

--- a/pages/index.js
+++ b/pages/index.js
@@ -123,7 +123,6 @@ export default function lifejourney({ journeysData }) {
                 id="parentingNetworks"
               />
               <ResourceLink
-                language={language}
                 region={region.current}
                 isProvincialLink={true}
               ></ResourceLink>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -307,3 +307,13 @@ html {
 .footerBackground {
   background: #26374a url(../public/images/landscape.png) no-repeat right bottom;
 }
+
+.sr-only:not(:focus):not(:active) {
+  clip: rect(0 0 0 0); 
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap; 
+  width: 1px;
+}


### PR DESCRIPTION
# Description

[LJ-392 modify icons in connect to resources to make it clear that they are external links](https://lj-decd.atlassian.net/browse/LJ-392?atlOrigin=eyJpIjoiNWIwMjM2OGIzZmIyNGJkNjhjZDY2ZDZjYTQzZWMyZTIiLCJwIjoiaiJ9)

I changed the icon so it is more clear that it is an external link. I also added the `sr-only` class to `globals.css` that makes text visually hidden but is still announced by the screen reader. I used this to announce that the resource links open in a new window. I also removed the links for Canada from the French JSON as that was previously missed.

## Test Instructions

1. Download NVDA from [here](https://www.nvaccess.org/download/)
2. Pull in branch
3. Type `npm run dev`
4. Tab through the page until you get to the Resource Links to hear the narrator say the links open in a new window

## Meets Definition of Done

- [x] Meets design spec
- [x] unit tests are included
