### PR TITLE
Modifed skip link, added body text

### DIFF
--- a/components/atoms/Banner.js
+++ b/components/atoms/Banner.js
@@ -14,8 +14,9 @@ export const Banner = ({ headline }) => {
       >
         <div className="lg:container xxl:px-8 lg:px-4 xxl:mx-auto xxs:pl-4 lg:py-14 xxs:pt-8">
           <h1
-            id="wb-cont"
             className="lg:text-h1l text-h1 font-bold font-display py-20 lg:py-9 break-words xxs:pb-4"
+            id="wb-cont"
+            tabIndex="-1"
           >
             {headline}
           </h1>

--- a/components/atoms/Banner.js
+++ b/components/atoms/Banner.js
@@ -14,7 +14,7 @@ export const Banner = ({ headline }) => {
       >
         <div className="lg:container xxl:px-8 lg:px-4 xxl:mx-auto xxs:pl-4 lg:py-14 xxs:pt-8">
           <h1
-            className="lg:text-h1l text-h1 font-bold font-display py-20 lg:py-9 break-words xxs:pb-4"
+            className="w-max lg:text-h1l text-h1 font-bold font-display py-20 lg:py-9 break-words xxs:pb-4"
             id="wb-cont"
             tabIndex="-1"
           >

--- a/components/atoms/ResourceLink.js
+++ b/components/atoms/ResourceLink.js
@@ -49,7 +49,11 @@ export default function ResourceLink(props) {
           <span className="sr-only">{props.srOnly}</span>
         </a>
         <span className="pl-1">
-          <FontAwesomeIcon icon={faExternalLinkAlt} size="sm" />
+          <FontAwesomeIcon
+            icon={faExternalLinkAlt}
+            alt="External Link"
+            size="sm"
+          />
         </span>
       </div>
     </div>

--- a/components/atoms/Stages.js
+++ b/components/atoms/Stages.js
@@ -71,6 +71,7 @@ export default function Stages(props) {
           className="w-auto mb-2 px-2 h-8 rounded border bg-white border-gray-400 mt-2 overflow-ellipsis xxs:max-w-full focus:shadow-blue focus:border-custom-blue-focus focus-visible:outline-none"
           id="stage"
           onChange={onChangeHandler}
+          defaultValue={props.defaultValue}
         >
           <option key="0" value={0} defaultValue disabled>
             {props.stagesSelectPlaceholder}
@@ -147,4 +148,8 @@ Stages.propTypes = {
    * select label
    */
   stagesSelectPlaceholder: PropTypes.string.isRequired,
+  /**
+   * default value for select element
+   */
+  defaultValue: PropTypes.string,
 };

--- a/components/organisms/Header.js
+++ b/components/organisms/Header.js
@@ -42,13 +42,11 @@ export function Header({ breadcrumbItems }) {
 
   return (
     <>
-      <nav className="hidden" aria-label={t.skipToMainContent}>
+      <nav className="skip-main">
         <a
           id="skipToMainContent"
-          className="bg-custom-blue-dark text-white py-1 px-2 hover:bg-gray-dark"
-          href="#pageMainTitle"
-          data-cy-button={"skip-Content"}
-          role="button"
+          className="bg-custom-blue-dark text-white py-1 px-2 focus:outline-black-solid hover:bg-gray-dark"
+          href="#wb-cont"
           draggable="false"
         >
           {t.skipToMainContent}

--- a/locales/en.js
+++ b/locales/en.js
@@ -115,7 +115,9 @@ export default {
   // Having a baby
   topRequested:
     "Resources to help you make the right decisions along this journey ",
-  topRequestedLabel: "Showing top requests for:",
+  topRequestedLabel: "Showing content for:",
+  findGuidance:
+    "Find guidance and support to help you make the right decision for you along this journey.",
 
   //Table
 

--- a/locales/fr.js
+++ b/locales/fr.js
@@ -114,7 +114,9 @@ export default {
   // Having a baby
   topRequested:
     "Ressources pour vous aider à prendre les bonnes décisions tout au long de ce parcours.",
-  topRequestedLabel: "Afficher les principales demandes pour :",
+  topRequestedLabel: "Afficher le contenu pour :",
+  findGuidance:
+    "Trouvez des conseils et des outils pour vous aider à prendre les bonnes décisions pour vous tout au long de ce parcours.",
 
   //Table
 
@@ -194,8 +196,11 @@ export default {
   // Stages
   stagesTitle:
     "Découvrez les étapes du parcours de vie de l’arrivée d’un enfant",
-  stagesDescr:
+  stagesDescr: [
     "Apprenez-en plus sur les tâches importantes à accomplir à chaque étape du parcours.",
+    "To help parents discover what they don’t know, we mapped all the different things that could happen during the journey and made it into a tool that you can explore.",
+    "In this tool, you will find information about the common steps and service providers at each stage in your journey.",
+  ],
   stagesSubtitle: "FRENCH Journey Stages",
   stagesSelectTitle: "FRENCH Select a stage to learn more about the key stages",
   stagesSelectLabel: "Étape du parcours : ",

--- a/pages/index.js
+++ b/pages/index.js
@@ -120,26 +120,33 @@ export default function lifejourney({ journeysData }) {
                 {t.getConnected}
               </h3>
               <p className="text-base">{t.getConnectedDescription}</p>
-
-              <ResourceLink
-                text={t.moreInfoPrenatalClasses}
-                isProvincialLink={false}
-                id="prenatalClasses"
-                srOnly={t.newWindow}
-              />
-              <ResourceLink
-                text={t.moreInfoParentingNetworks}
-                isProvincialLink={false}
-                id="parentingNetworks"
-                srOnly={t.newWindow}
-                language={language}
-              />
-              <ResourceLink
-                region={region.current}
-                isProvincialLink={true}
-                srOnly={t.newWindow}
-                language={language}
-              ></ResourceLink>
+              <ul>
+                <li>
+                  <ResourceLink
+                    text={t.moreInfoPrenatalClasses}
+                    isProvincialLink={false}
+                    id="prenatalClasses"
+                    srOnly={t.newWindow}
+                  />
+                </li>
+                <li>
+                  <ResourceLink
+                    text={t.moreInfoParentingNetworks}
+                    isProvincialLink={false}
+                    id="parentingNetworks"
+                    srOnly={t.newWindow}
+                    language={language}
+                  />
+                </li>
+                <li>
+                  <ResourceLink
+                    region={region.current}
+                    isProvincialLink={true}
+                    srOnly={t.newWindow}
+                    language={language}
+                  ></ResourceLink>
+                </li>
+              </ul>
             </div>
           </div>
         </section>

--- a/pages/index.js
+++ b/pages/index.js
@@ -31,13 +31,8 @@ export default function lifejourney({ journeysData }) {
         bannerText={t.havingAChildBannerText}
         locale={language}
       >
-        {/*  id="wb-cont"  the id should go in the H1 adding it here for now because Kris is updating the header */}
-
-        <section
-          id="wb-cont"
-          id="pageMainTitle"
-          className="layout-container mb-2 mt-4"
-        >
+        <section className="layout-container mb-2 mt-4">
+          <p className="mx-3 pt-2 pb-6">{t.findGuidance}</p>
           <Select
             options={language === "en" ? optionsEN : optionsFR}
             onChange={onChangeFunc}

--- a/pages/index.js
+++ b/pages/index.js
@@ -107,6 +107,7 @@ export default function lifejourney({ journeysData }) {
                 stagesSelectTitle={t.stagesSelectTitle}
                 stagesSelectLabel={t.stagesSelectLabel}
                 stagesSelectPlaceholder={t.stagesSelectPlaceholder}
+                defaultValue="0"
               />
             </div>
           </div>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -317,3 +317,11 @@ html {
   white-space: nowrap; 
   width: 1px;
 }
+
+.skip-main{
+  @apply absolute w-px h-px -left-96
+}
+
+.skip-main:focus-within{
+  @apply absolute w-screen h-auto top-16 left-0 z-50 flex justify-center
+}


### PR DESCRIPTION
# Description

I modified the skip link to link to the H1 on the page. Additionally, I added the body text above the province selector as per Steph's Figma. I also temporarily added a couple English items to the French `stageDescr` translation array since it was a single item and was breaking when you switched to French.

## Test Instructions

1. Pull in branch
2. Type `npm run dev`
3. Open dev console and right click the skip link line -> Focus to see the skip link show up

## Meets Definition of Done

- [x] Meets design spec

