### PR TITLE
Fixes as per most recent a11y audit

### DIFF
--- a/components/atoms/Stages.js
+++ b/components/atoms/Stages.js
@@ -103,7 +103,9 @@ export default function Stages(props) {
                 {subJourney.content.map(({ title, list }, idx) => (
                   <div key={idx}>
                     {title !== "hidden" ? (
-                      <h4 className="text-base -mx-4">{title}</h4>
+                      <strong>
+                        <h6 className="text-base -mx-4">{title}</h6>
+                      </strong>
                     ) : (
                       ""
                     )}

--- a/components/organisms/Header.js
+++ b/components/organisms/Header.js
@@ -69,7 +69,7 @@ export function Header({ breadcrumbItems, locale }) {
                 }
                 alt={
                   language === "en"
-                    ? "Symbol of the Government of Canada"
+                    ? "Government of Canada"
                     : "Gouvernement du Canada"
                 }
               />


### PR DESCRIPTION
# Description

This PR addresses 2 small a11y issues as per the most recent audit. This includes removing the `Symbol of the` portion from the English alt text for the Government of Canada logo and also fixes the heading hierarchy (so it goes h4-h5-h6 instead of h4-h5-h4) 

## Test Instructions

1. Pull in branch
2. Type `npm run dev`
3. Open dev console and inspect the accordions and the Government of Canada logo to see the above fixes

## Meets Definition of Done

- [x] Meets design spec
- [x] unit tests are included
