### PR TITLE
Temporarily remove ReportAProblem

### DIFF
--- a/components/organisms/PageDetails.js
+++ b/components/organisms/PageDetails.js
@@ -17,9 +17,12 @@ export function PageDetails() {
 
   return (
     <>
-      <div className="layout-container my-3">
-        <ReportProblem language={language} />
-      </div>
+      {/**
+         temporarily removing this piece while usability testing is happening for the Feeedback component
+         */}
+      {/*<div className="layout-container my-3">*/}
+      {/*  <ReportProblem language={language} />*/}
+      {/*</div>*/}
 
       <div className="layout-container">
         <DateModified text={t.dateModified} />


### PR DESCRIPTION
# Description

In order to perform the usability testing for the feedback widget, the PO wants only one way to report anything, so we're removing the Report A Problem component for now.
